### PR TITLE
statwrap.fpp.scatter_plot update– inbuilt regline equation

### DIFF
--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -54,7 +54,7 @@ def box_model(*args, with_replacement = True, draws = 1, random_seed = None):
 
 def scatter_plot(x, y, xlim=None, ylim=None,
               ax=None, show=True, save_as=None, xlabel=None,
-              ylabel=None, title=None, regression_line=False, **kwargs):
+              ylabel=None, title=None, regression_line=False, regression_equation=False, **kwargs):
     """
     Create a scatter plot of `x` versus `y`, with specified axis labels, limits, title, and other properties.
     Optionally, a regression line can be added to the plot.
@@ -115,6 +115,11 @@ def scatter_plot(x, y, xlim=None, ylim=None,
     if regression_line:
         m, b = np.polyfit(x, y, 1)  # Calculating the slope (m) and intercept (b) of the regression line
         ax.plot(x, m*x + b, color='gray')  # Plotting the regression line
+
+    if regression_equation: 
+        equation_text = f'y = {m:.2f}x + {b:.2f}'  # Add regression line equation to plot
+        ax.text(0.5 , 1, equation_text, transform=ax.transAxes, fontsize=10,
+                verticalalignment='bottom', horizontalalignment='center', alpha=0.5)
 
     if xlim is not None:
         ax.set_xlim(xlim)


### PR DESCRIPTION
Added functionality to scatter_plot function; additional parameter to display equation of regression line on the plot

def scatter_plot(x, y, xlim=None, ylim=None,
              ax=None, show=True, save_as=None, xlabel=None,
              ylabel=None, title=None, regression_line=False, regression_equation=False, **kwargs):

if regression_line=False:

<img width="1138" alt="Screenshot 2024-07-11 at 9 51 38 AM" src="https://github.com/tzwickk/statwrap/assets/163785418/a2b05026-a5be-4e60-9b69-186c95d9c190">

if True:

<img width="1166" alt="Screenshot 2024-07-11 at 9 52 15 AM" src="https://github.com/tzwickk/statwrap/assets/163785418/64501aa6-4ec1-4030-b845-57fe9aaa78dd">

